### PR TITLE
Allow project id override

### DIFF
--- a/.github/workflows/publish-terraform-module.yml
+++ b/.github/workflows/publish-terraform-module.yml
@@ -1,41 +1,16 @@
 # When a commit is made to main, perform a GitHub release, bumping the semantic
 # version. Defaults to `default-bump` param, override with
 # `#major`/`#minor`/`#patch` in the commit message
-name: Validate and Publish Terraform module
+name: Publish Terraform Module
 
 on:
   push:
     branches:
-      - "*"
+      - "main"
 
 jobs:
-  validate:
-    name: Validate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Terraform cli
-        uses: hashicorp/setup-terraform@v3
-      - name: Terraform fmt
-        run: |
-          set +e
-          terraform fmt -check
-          if [[ $? -ne 0 ]]; then
-            echo "Be sure to run 'terraform fmt' before committing. This can usually be done in your IDE of choice"
-            exit 1
-          fi
-          set -e
-      - name: TF init
-        run: terraform init -input=false -backend=false
-      - name: TF validate
-        run: terraform validate
-
   release:
     name: GitHub Release
-    if: github.ref == 'refs/heads/main'
-    needs:
-      - validate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,9 +2,8 @@ name: Validate Terraform module
 
 on:
   push:
-    branches:
-      - "*"
-      - "!main"
+    branches-ignore:
+      - "main"
 
 jobs:
   validate:
@@ -14,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Set up Terraform cli
-        uses: hashicorp/setup-terraform@v1
+        uses: hashicorp/setup-terraform@v3
       - name: Terraform fmt
         run: |
           set +e

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 locals {
+  # Max project id is 30 chars, and we are appending a dash and 4 random chars
+  # Also trim trailing dash in case truncated string ends with a dash
   project_id        = var.project_id != null ? var.project_id : trim(substr("${var.name}-${var.env_id}", 0, 25), "-")
   random_project_id = var.project_id == null ? true : false
 }
@@ -8,8 +10,6 @@ module "domain_project_factory" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 15.0"
 
-  # Max project id is 30 chars, and we are appending a dash and 4 random chars
-  # Also trim trailing dash in case truncated string ends with a dash
   project_id                  = local.project_id
   name                        = substr("${var.name} ${var.env_name}", 0, 30)
   billing_account             = var.billing_account

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,8 @@
+locals {
+  project_id        = var.project_id != null ? var.project_id : trim(substr("${var.name}-${var.env_id}", 0, 25), "-")
+  random_project_id = var.project_id == null ? true : false
+}
+
 # Provision a project for the domain
 module "domain_project_factory" {
   source  = "terraform-google-modules/project-factory/google"
@@ -5,10 +10,10 @@ module "domain_project_factory" {
 
   # Max project id is 30 chars, and we are appending a dash and 4 random chars
   # Also trim trailing dash in case truncated string ends with a dash
-  project_id                  = trim(substr("${var.name}-${var.env_id}", 0, 25), "-")
+  project_id                  = local.project_id
   name                        = substr("${var.name} ${var.env_name}", 0, 30)
   billing_account             = var.billing_account
-  random_project_id           = true
+  random_project_id           = local.random_project_id
   org_id                      = var.org_id
   folder_id                   = var.env_folder_id
   activate_apis               = var.activate_apis

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "default_service_account" {
 }
 
 variable "project_id" {
-  description = "Use this to explicitly set the project id. If not set, the project id will be generated from the (domain) name, env_id, and a random suffix."
+  description = "Use this to explicitly set the project ID. If not set, the project ID will be generated from the domain name, env_id, and a random suffix."
   default     = null
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -47,3 +47,9 @@ variable "default_service_account" {
   default     = "deprivilege"
   type        = string
 }
+
+variable "project_id" {
+  description = "Use this to explicitly set the project id. If not set, the project id will be generated from the (domain) name, env_id, and a random suffix."
+  default     = null
+  type        = string
+}


### PR DESCRIPTION
Introduce a new module input, project_id, to explicitly set the project id.
If not set, the project id will be generated from the (domain) name, env_id, and a random suffix.
